### PR TITLE
Add extract-style.js to parse style.xml to JSON with error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,14 @@
+# Node dependencies
 node_modules/
+
+# Uploaded files (temp uploads from multer)
 uploads/
+
+# Ignore all .itmz files except the sample
 *.itmz
 !sample-data/example-map.itmz
+
+# Extracted files (generated artifacts)
 mapdata_extracted.xml
+style_extracted.json
+style_extracted.xml

--- a/extract-style.js
+++ b/extract-style.js
@@ -1,0 +1,42 @@
+const AdmZip = require('adm-zip');
+const fs = require('fs');
+const path = require('path');
+const { XMLParser } = require('fast-xml-parser');
+
+// Replace this with your actual .itmz path
+const itmzFilePath = './sample-data/example-map.itmz';
+
+const zip = new AdmZip(itmzFilePath);
+const styleEntry = zip.getEntry('style.xml');
+
+if (!styleEntry) {
+  console.error('style.xml not found in .itmz file');
+  process.exit(1);
+}
+
+const xmlContent = styleEntry.getData().toString('utf8');
+
+// Save XML (optional)
+const outputPath = path.join(__dirname, 'style_extracted.xml');
+fs.writeFileSync(outputPath, xmlContent);
+console.log(`style.xml extracted and saved to ${outputPath}`);
+
+// Parse to JSON
+const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: "@_"
+});
+
+let json;
+
+try {
+    json = parser.parse(xmlContent);
+} catch (err) {
+    console.error('Error parsing XML:', err);
+    process.exit(1);
+}
+
+// Save JSON
+const jsonOutputPath = path.join(__dirname, 'style_extracted.json');
+fs.writeFileSync(jsonOutputPath, JSON.stringify(json, null, 2));
+console.log(`✅ style JSON saved to ${jsonOutputPath}`);


### PR DESCRIPTION
_Description:_
This pull request adds a script to extract and parse the `style.xml` file from an `.itmz` mind map file. The script outputs both the raw XML and a parsed JSON version for inspection and backend use. This is an essential step toward understanding and reconstructing the visual styling of mind maps, including fonts, colors, shapes, and line styles.

_Acceptance Criteria:_
- Extracts `style.xml` from `.itmz` archive.
- Parses `style.xml` into JSON, capturing:
> Top-level style attributes (e.g. canvas style, link colors, font settings).
> Level-specific overrides (e.g. topic shapes, font sizes).
- Outputs both:
> `style_extracted.xml`
> `style_extracted.json`
- Gracefully handles:
> Missing `style.xml`
> Invalid or malformed XML

_Files Added/Changed:_
- `extract-style.js` — New script to extract and parse styles.
- `.gitignore` — Updated to ignore output files (`style_extracted.xml` and `style_extracted.json`).
- `README.md` — (Optional: can be updated later to document this script if not already).

_Testing Steps:_
Run:
`node extract-style.js`
Confirm:
- `style_extracted.xml` is created with the raw XML.
- `style_extracted.json` contains structured style data.
Test with:
- A valid `.itmz` file in `/sample-data/`.
- A missing or renamed `.itmz` file — should exit with a clear error.
- A corrupted `style.xml` (optional) — should show parse error.

_Notes:_
- This feature sets the groundwork for applying styles when rendering mind maps in a future frontend or UI.
- No impact on the server-side API (`server.js`) yet — purely a utility for development and inspection.
