### PR TITLE
Add JSON parsing to extract-mapdata.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ uploads/
 !sample-data/example-map.itmz
 
 # Extracted files (generated artifacts)
+mapdata_extracted.json
 mapdata_extracted.xml
 style_extracted.json
 style_extracted.xml

--- a/extract-mapdata.js
+++ b/extract-mapdata.js
@@ -1,6 +1,7 @@
 const AdmZip = require('adm-zip');
 const fs = require('fs');
 const path = require('path');
+const { XMLParser } = require('fast-xml-parser');
 
 // Replace this with your actual .itmz path
 const itmzFilePath = './sample-data/example-map.itmz';
@@ -15,9 +16,27 @@ if (!mapdataEntry) {
 
 const xmlContent = mapdataEntry.getData().toString('utf8');
 
-// Save to local file so you can open it in any text editor
-const outputPath = path.join(__dirname, 'mapdata_extracted.xml');
+// Save XML (optional)
+const xmlOutputPath = path.join(__dirname, 'mapdata_extracted.xml');
+fs.writeFileSync(xmlOutputPath, xmlContent);
+console.log(`mapdata.xml extracted and saved to ${xmlOutputPath}`);
 
-fs.writeFileSync(outputPath, xmlContent);
+// Parse to JSON
+const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: "@_"
+});
 
-console.log(`mapdata.xml extracted and saved to ${outputPath}`);
+let json;
+
+try {
+    json = parser.parse(xmlContent);
+} catch (err) {
+    console.error('Error parsing XML:', err);
+    process.exit(1);
+}
+
+// Save JSON
+const jsonOutputPath = path.join(__dirname, 'mapdata_extracted.json');
+fs.writeFileSync(jsonOutputPath, JSON.stringify(json, null, 2));
+console.log(`✅ mapdata JSON saved to ${jsonOutputPath}`);

--- a/extract-style.js
+++ b/extract-style.js
@@ -17,9 +17,9 @@ if (!styleEntry) {
 const xmlContent = styleEntry.getData().toString('utf8');
 
 // Save XML (optional)
-const outputPath = path.join(__dirname, 'style_extracted.xml');
-fs.writeFileSync(outputPath, xmlContent);
-console.log(`style.xml extracted and saved to ${outputPath}`);
+const xmlOutputPath = path.join(__dirname, 'style_extracted.xml');
+fs.writeFileSync(xmlOutputPath, xmlContent);
+console.log(`style.xml extracted and saved to ${xmlOutputPath}`);
 
 // Parse to JSON
 const parser = new XMLParser({

--- a/mapdata_extracted.xml
+++ b/mapdata_extracted.xml
@@ -1,0 +1,18 @@
+<iThoughts version="4.0" app="com.toketaware.ithoughtsx.mas" app-version="9.3" modified="2025-06-26T09:57:31" author="Mark’s MacBook Pro (2) [markbond]" system-version="Version 13.2.1 (Build 22D68)"><topics>
+<topic uuid="B2A12D2E-41B0-4EB1-BCF9-C64312CF8949" position="{0, 0}" text="Core Node" created="2025-06-24T20:11:44" modified="2025-06-26T09:29:20">
+<topic uuid="7C3DDCA5-D764-4D2B-820C-E75085738C8F" position="{166, -130}" text="Parent " created="2025-06-24T20:11:51" modified="2025-06-26T09:29:36">
+<topic uuid="8CDC7A7E-261A-481C-A2EA-B8F885363E20" position="{145, 0}" text="Child" created="2025-06-24T20:12:03" modified="2025-06-26T09:36:32">
+</topic>
+</topic>
+<topic uuid="0E2F1E96-944B-4D96-8EC2-B6AC6EF415E1" position="{166, 25}" text="Parent" created="2025-06-24T20:11:58" modified="2025-06-26T09:29:48">
+<topic uuid="30316B03-41A4-4584-9338-76A1E298DA14" position="{176, -105}" text="Child with links" link="https://github.com/harmonoman" created="2025-06-24T20:12:09" modified="2025-06-26T09:36:30">
+</topic>
+<topic uuid="AFD0AECD-3E91-41AC-9053-5A4840A705C9" position="{186, 25}" text="Child with pictures" created="2025-06-24T20:12:32" modified="2025-06-26T09:30:29">
+<topic uuid="166881F7-20C8-4B36-91DF-83E7E536553B" position="{254, 0}" text-size="4" text-width="479.398438" image-width="279.398438" att-id="B4E1B655-CC63-4A3E-B925-277CFA962690" att-name="image.png" created="2025-06-24T20:13:17" modified="2025-06-24T20:13:19">
+</topic>
+</topic>
+</topic>
+</topic>
+</topics><relationships>
+</relationships>
+</iThoughts>


### PR DESCRIPTION
_Description:_
This update enhances `extract-mapdata.js` by adding XML-to-JSON parsing using `fast-xml-parser`. The script now outputs both `mapdata_extracted.xml` and `mapdata_extracted.json`, allowing developers to inspect and utilize the map data in a structured JSON format.

_Changes Include:_
- Parse `mapdata.xml` into JSON
- Save both the raw XML and the parsed JSON to disk
- Added error handling for missing files and XML parsing errors
- Matches the pattern and structure used in extract-style.js
- Added mapdata_extracted.json to .gitignore to avoid committing local data artifacts

_Acceptance Criteria:_
- Both XML and JSON files are generated successfully
- JSON contains topic hierarchy, UUIDs, links, and other node data
- Errors are handled gracefully if `mapdata.xml` is missing or invalid
- Temporary JSON files are ignored from Git version control
