### PR TITLE
feat: add script to extract and parse preferences.plist

### DIFF
--- a/extract-scripts/extract-preferences.js
+++ b/extract-scripts/extract-preferences.js
@@ -1,0 +1,43 @@
+const AdmZip = require('adm-zip');
+const fs = require('fs');
+const path = require('path');
+const plist = require('plist');
+
+// Path to the .itmz file
+const itmzFilePath = './sample-data/example-map.itmz';
+
+// Ensure the output folder exists
+const outputDir = path.join(__dirname, '../extracted-data');
+if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir);
+}
+
+const zip = new AdmZip(itmzFilePath);
+const preferencesEntry = zip.getEntry('preferences.plist');
+
+if(!preferencesEntry) {
+    console.error('❌ preferences.plist not found in .itmz file');
+    process.exit(1);
+}
+
+const plistContent = preferencesEntry.getData().toString('utf8');
+
+// Save raw plist (optional)
+const plistOutputPath = path.join(__dirname, '../extracted-data/preferences_extracted.plist');
+fs.writeFileSync(plistOutputPath, plistContent);
+console.log(`preferences.plist extracted and saved to ${plistOutputPath}`);
+
+// Parse plist to JSON
+let json;
+
+try{
+    json = plist.parse(plistContent);
+} catch (err) {
+    console.error('❌ Error parsing preferences.plist:', err);
+    process.exit(1);
+}
+
+// Save JSON
+const jsonOutputPath = path.join(__dirname, '../extracted-data/preferences_extracted.json');
+fs.writeFileSync(jsonOutputPath, JSON.stringify(json, null, 2));
+console.log(`✅ preferences JSON saved to ${jsonOutputPath}`);


### PR DESCRIPTION
_Description:_
This PR adds functionality to extract and parse `preferences.plist` from `.itmz` mind map files. The extracted data is parsed into JSON and saved for backend use or developer inspection.

_Changes:_
- Added `extract-preferences.js` script in `extract-scripts/`
- Parses `preferences.plist` into JSON
- Saves output to `extracted-data/preferences_extracted.json`
- Includes error handling for missing files or invalid parsing
- Updated `.gitignore` to exclude extracted data

_Acceptance Criteria:_
- The script successfully extracts `preferences.plist` from the `.itmz` file.
- The extracted file is parsed into a valid JSON object.
- The output JSON is saved in `/extracted-data/` as `preferences_extracted.json`.
- Graceful handling of missing files and parsing errors.
- Temporary extracted files are ignored via `.gitignore`.

_Summary:_
This enables the project to capture user or system preferences from iThoughts mind maps. These preferences (e.g., `HideCallouts`, `SnapToTopic`) may inform frontend rendering logic in the future.