### PR TITLE
feat: add /preview/:mapId route to serve preview.png from .itmz files

### DIFF
--- a/server.js
+++ b/server.js
@@ -85,6 +85,31 @@ app.get('/image/:id', (req, res) => {
   res.send(imageData);
 });
 
+// Get and serve the preview image of the map
+app.get('/preview/:mapId', (req, res) => {
+    const mapId = req.params.mapId.trim();
+    const itmzFile = `./sample-data/${mapId}.itmz`;
+  
+    console.log(`🔍 Attempting to open preview from ${itmzFile}`);
+  
+    try {
+      const zip = new AdmZip(itmzFile);
+      const previewEntry = zip.getEntry('preview.png');
+  
+      if (!previewEntry) {
+        console.log(`❌ preview.png not found in ${itmzFile}`);
+        return res.status(404).send('Preview not found');
+      }
+  
+      const previewData = previewEntry.getData();
+      res.set('Content-Type', 'image/png');
+      res.send(previewData);
+    } catch (err) {
+      console.error('Error reading preview:', err);
+      res.status(500).send('Error processing preview');
+    }
+  });
+
 // ✅ app.listen should always be LAST
 app.listen(port, () => {
   console.log(`Server listening at http://localhost:${port}`);


### PR DESCRIPTION
_Description:_
- Implemented a new GET route `/preview/:mapId` in `server.js`.
- This route opens the specified `.itmz` file inside `sample-data/` based on the `mapId` parameter.
- Extracts and serves the `preview.png` image embedded in the `.itmz`.
- Useful for frontend file picker UIs that want to display map previews.
- Graceful handling of errors such as missing files or preview images.
- Returns HTTP 404 if `preview.png` not found and 500 for other processing errors.

